### PR TITLE
25 add endpoint post users which creates new user or throws 409

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -104,10 +104,9 @@ public class UserService {
    */
   private void checkIfUserExists(User userToBeCreated) {
     User userByUsername = userRepository.findByUsername(userToBeCreated.getUsername());
-
-    String baseErrorMessage = "The %s provided %s not unique. Therefore, the user could not be created!";
+    
     if (userByUsername != null) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, String.format(baseErrorMessage, "username", "is"));
-    }
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Username already taken");
+    } 
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -106,6 +106,54 @@ public class UserControllerTest {
         .andExpect(jsonPath("$.status", is(user.getStatus().toString())));
   }
 
+  @Test
+  public void createUser_Username_taken() throws Exception {
+    // // create first user
+    // User user = new User();
+    // user.setUsername("testUsername");
+
+
+    // User user_2 = new User();
+    // user_2.setUsername("testUsername");
+
+    // UserPostDTO userPostDTO = new UserPostDTO();
+    // userPostDTO.setUsername("testUsername");
+
+    // UserPostDTO userPostDTO_2 = new UserPostDTO();
+    // userPostDTO.setUsername("testUsername");
+
+    // given(userService.createUser(Mockito.any())).willReturn(user);
+    // given(userService.createUser(Mockito.any())).willReturn(user_2);
+
+    // // when/then -> do the request + validate the result
+    // MockHttpServletRequestBuilder postRequest_1 = post("/users")
+    //     .contentType(MediaType.APPLICATION_JSON)
+    //     .content(asJsonString(userPostDTO));
+
+    // MockHttpServletRequestBuilder postRequest_2 = post("/users")
+    //     .contentType(MediaType.APPLICATION_JSON)
+    //     .content(asJsonString(userPostDTO_2));
+
+    // // then
+    // mockMvc.perform(postRequest_2)
+    //     .andExpect(status().isConflict());
+
+    UserPostDTO userPostDTO_conflict = new UserPostDTO();
+    userPostDTO_conflict.setUsername("username");
+    userPostDTO_conflict.setPassword("password_conflict");
+
+    given(userService.createUser(Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.CONFLICT));
+    // mock auth token
+    given(authenticationInterceptor.preHandle(Mockito.any(), Mockito.any(), Mockito.any())).willReturn(true);
+    
+    MockHttpServletRequestBuilder postRequest_conflict = post("/users")
+    .contentType(MediaType.APPLICATION_JSON)
+    .content(asJsonString(userPostDTO_conflict));
+
+    mockMvc.perform(postRequest_conflict).andExpect(status().isConflict());
+
+  }
+
   /**
    * Helper Method to convert userPostDTO into a JSON string such that the input
    * can be processed

--- a/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs24/controller/UserControllerTest.java
@@ -140,7 +140,7 @@ public class UserControllerTest {
 
     UserPostDTO userPostDTO_conflict = new UserPostDTO();
     userPostDTO_conflict.setUsername("username");
-    userPostDTO_conflict.setPassword("password_conflict");
+    userPostDTO_conflict.setPassword("password");
 
     given(userService.createUser(Mockito.any())).willThrow(new ResponseStatusException(HttpStatus.CONFLICT));
     // mock auth token


### PR DESCRIPTION
updated the testcase for creating a user with an already existing username, now returns error code 409 as defined in the REST specifications.